### PR TITLE
Stop treating files in documentation directories as code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,7 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Documentation directories
+doc/javadoc/* linguist-documentation
+SwerveRoboticsLibrary/doc/* linguist-documentation


### PR DESCRIPTION
This way, files in documentation directories will no longer "pollute" the language stats as seen by [GitHub Linguist](https://github.com/github/linguist).

Before:
![screenshot from 2016-03-06 15-25-26](https://cloud.githubusercontent.com/assets/13669330/13556804/e2003d00-e3b0-11e5-817c-e21b71503443.png)

After: (obviously without the jump in the number of commits!)
![screenshot from 2016-03-06 15-25-17](https://cloud.githubusercontent.com/assets/13669330/13556800/d41b21fa-e3b0-11e5-83da-83751e93f69a.png)

(Brown represents Java, red represents HTML)
